### PR TITLE
Defer closing procNSFile instead

### DIFF
--- a/garden-plugin/fake-netplugin-daemon/main.go
+++ b/garden-plugin/fake-netplugin-daemon/main.go
@@ -33,13 +33,19 @@ func main() {
 
 	defer listener.Close()
 
+	var procNSFile *os.File
+	var msg message.Message
+
+	defer procNSFile.Close()
+
 	for {
+		var err error
 		conn, err := listener.AcceptUnix()
 		if err != nil {
 			panic(err)
 		}
 
-		procNSFile, msg, err := shimsocket.Receive(conn)
+		procNSFile, msg, err = shimsocket.Receive(conn)
 		if err != nil {
 			panic(err)
 		}
@@ -68,6 +74,5 @@ func main() {
 		}
 
 		conn.Close()
-		procNSFile.Close()
 	}
 }


### PR DESCRIPTION
Context: https://ci.funtime.lol/teams/wg-arp-garden/pipelines/garden-runc-release/jobs/unit-and-integration-tests/builds/39

Closing it earlier causes error in some tests in concourse. The reason this was changed in the first place was because staticcheck detected that defer within the for loop would've never happened.